### PR TITLE
Fix Visual Studio build for LxExt.

### DIFF
--- a/lxext/lxext.vcxproj
+++ b/lxext/lxext.vcxproj
@@ -8,23 +8,31 @@
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalOptions>-Wno-unknown-pragmas -shared %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-Wno-unknown-pragmas -shared -fPIC %(AdditionalOptions)</AdditionalOptions>
       <Verbose>true</Verbose>
-      <PositionIndependentCode>true</PositionIndependentCode>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
       <CLanguageStandard>gnu11</CLanguageStandard>
-      <CppLanguageStandard>gnu++1y</CppLanguageStandard>
-      <CompileAs>CompileAsCpp</CompileAs>
+      <CppLanguageStandard>Default</CppLanguageStandard>
     </ClCompile>
     <Link>
-      <LibraryDependencies>pthread</LibraryDependencies>
+      <LibraryDependencies>pthread;dl</LibraryDependencies>
       <ShowProgress>
       </ShowProgress>
       <VerboseOutput>
       </VerboseOutput>
+      <OutputFile>lxext.so</OutputFile>
+      <AdditionalOptions>-shared %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="lxext.c" />
+    <ClCompile Include="lxext.c">
+      <CLanguageStandard>gnu11</CLanguageStandard>
+      <CppLanguageStandard>Default</CppLanguageStandard>
+      <ThreadSafeStatics>
+      </ThreadSafeStatics>
+      <RuntimeTypeInfo>
+      </RuntimeTypeInfo>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\inc\adss.h" />


### PR DESCRIPTION
`typeof()` is a GNU extension to the language, so it needs -std=gnu11 to compile. For some reason, the build process was ignoring that switch at the project level. It worked when I put it directly on `lcexe.c`.

It's probably a bug in the `Visual C++ for Linux Development` extension, but it was easy enough to work around.

Also, setting `RuntimeTypeInfo` and `ThreadSafeStatics` to empty strings and `CppLanguageStandard` to `Default` got rid of a couple warnings that I saw on other projects as well.