### PR TITLE
Restructure `lxext.vcxproj` so project properties propagate down to source files.

### DIFF
--- a/lxext/lxext.vcxproj
+++ b/lxext/lxext.vcxproj
@@ -6,44 +6,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <AdditionalOptions>-Wno-unknown-pragmas -shared %(AdditionalOptions)</AdditionalOptions>
-      <Verbose>
-      </Verbose>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
-      <CLanguageStandard>
-      </CLanguageStandard>
-      <CppLanguageStandard>
-      </CppLanguageStandard>
-      <PositionIndependentCode>
-      </PositionIndependentCode>
-    </ClCompile>
-    <Link>
-      <LibraryDependencies>pthread;dl</LibraryDependencies>
-      <ShowProgress>
-      </ShowProgress>
-      <VerboseOutput>
-      </VerboseOutput>
-      <OutputFile>lxext.so</OutputFile>
-      <AdditionalOptions>-shared %(AdditionalOptions)</AdditionalOptions>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="lxext.c">
-      <CLanguageStandard>gnu11</CLanguageStandard>
-      <CppLanguageStandard>Default</CppLanguageStandard>
-      <ThreadSafeStatics>
-      </ThreadSafeStatics>
-      <RuntimeTypeInfo>
-      </RuntimeTypeInfo>
-      <PositionIndependentCode Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</PositionIndependentCode>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\inc\adss.h" />
-    <ClInclude Include="..\inc\linux.h" />
-  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{f12a920c-f002-45d0-a884-f7192b00124f}</ProjectGuid>
     <Keyword>Linux</Keyword>
@@ -68,6 +30,28 @@
     <TargetExt>.so</TargetExt>
     <TargetName>$(ProjectName)</TargetName>
   </PropertyGroup>
+  <ItemGroup>
+    <ClCompile Include="lxext.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\inc\adss.h" />
+    <ClInclude Include="..\inc\linux.h" />
+  </ItemGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalOptions>-Wno-unknown-pragmas %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <CLanguageStandard>gnu11</CLanguageStandard>
+      <ThreadSafeStatics>
+      </ThreadSafeStatics>
+      <RuntimeTypeInfo>
+      </RuntimeTypeInfo>
+      <PositionIndependentCode>true</PositionIndependentCode>
+    </ClCompile>
+    <Link>
+      <LibraryDependencies>pthread;dl</LibraryDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>


### PR DESCRIPTION
I rearranged the sections so they appear in the same order as a newly generated blank Linux project, then moved the important settings back up the the project level. That seems to appease the MSBuild gods and project properties aren't being ignored anymore.

On a different subject:
If you ever see: ```error : Current project architecture 'x64' is incompatible with the remote machine architecture 'x86_64``` when building, there's a good chance its because `lxext.so` is still in `/etc/ld.so.preload` but isn't on disk anymore. It seems that the error message printed when a preload library is missing interferes with Visual Studio's call to `uname -m` at the start of the build.